### PR TITLE
Adds Leaflet.Editable to Map component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "gatsby-source-filesystem": "^4.21.0",
         "leaflet-active-area": "^1.2.1",
         "leaflet-draw": "^1.0.4",
+        "leaflet-editable": "^1.2.0",
         "memoizee": "^0.4.15",
         "mkdirp": "^1.0.4",
         "moment": "^2.29.1",
@@ -33099,6 +33100,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
       "integrity": "sha1-Rb6S83jtJT5yAv3tofzHGIUZjUY="
+    },
+    "node_modules/leaflet-editable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-editable/-/leaflet-editable-1.2.0.tgz",
+      "integrity": "sha512-wG11JwpL8zqIbypTop6xCRGagMuWw68ihYu4uqrqc5Ep0wnEJeyob7NB2Rt5t74Oih4rwJ3OfwaGbzdowOGfYQ=="
     },
     "node_modules/legacy-swc-helpers": {
       "name": "@swc/helpers",
@@ -72023,6 +72029,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
       "integrity": "sha1-Rb6S83jtJT5yAv3tofzHGIUZjUY="
+    },
+    "leaflet-editable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-editable/-/leaflet-editable-1.2.0.tgz",
+      "integrity": "sha512-wG11JwpL8zqIbypTop6xCRGagMuWw68ihYu4uqrqc5Ep0wnEJeyob7NB2Rt5t74Oih4rwJ3OfwaGbzdowOGfYQ=="
     },
     "legacy-swc-helpers": {
       "version": "npm:@swc/helpers@0.4.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fogg",
-  "version": "0.5.0",
+  "version": "0.5.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fogg",
-      "version": "0.5.0",
+      "version": "0.5.1-0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gatsby-source-filesystem": "^4.21.0",
     "leaflet-active-area": "^1.2.1",
     "leaflet-draw": "^1.0.4",
+    "leaflet-editable": "^1.2.0",
     "memoizee": "^0.4.15",
     "mkdirp": "^1.0.4",
     "moment": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fogg",
   "description": "Gatsby theme for mapping!",
-  "version": "0.5.0",
+  "version": "0.5.1-0",
   "author": "Element 84, Inc.",
   "publishConfig": {
     "registry": "https://registry.npmjs.com/"

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -6,6 +6,7 @@ import { Map as BaseMap, LayersControl, ZoomControl } from 'react-leaflet';
 import 'proj4';
 import 'proj4leaflet';
 import 'leaflet-active-area';
+import 'leaflet-editable';
 
 import MapService from '../../models/map-service';
 import { LayersContext } from '../../context';
@@ -125,7 +126,8 @@ const Map = (props) => {
     maxZoom: maxZoom || baseMaxZoom,
     minZoom: minZoom || baseMinZoom,
     maxNativeZoom: baseMaxNativeZoom,
-    zoomControl: false
+    zoomControl: false,
+    editable: true
   };
 
   // Only set up a new CRS if one is provided, otherwise fallback to the leaflet defaults (3857)

--- a/src/components/MapPreviewDraw/MapPreviewDraw.js
+++ b/src/components/MapPreviewDraw/MapPreviewDraw.js
@@ -92,7 +92,7 @@ const MapPreviewDraw = ({
    */
 
   function handleOnEdited ({ target } = {}) {
-    if (typeof onCreated === 'function') {
+    if (typeof onEdited === 'function') {
       onEdited(target, forwardedRef);
     }
   }
@@ -109,6 +109,7 @@ const MapPreviewDraw = ({
             onEdited={handleOnEdited}
             draw={drawOptions}
             edit={{
+              featureGroup: featureRef,
               edit: !disableEditControls,
               remove: false
             }}


### PR DESCRIPTION
Allows for programmatic enabling of layer editing.

### Example

```JavaScript
const layers = featureGroup.getLayers();
layers.forEach((layer) => {
  layer.enableEdit();
  layer.on('editable:editing', (layer, leafletElement) => console.log('edit event'));
});
```

### See also

[Leaflet.Editable](https://github.com/Leaflet/Leaflet.Editable) for more documentation on usage.

### Some background

We initially were going about the edit route via Leaflet.draw, until we ran into an issue similar to the one [described here](https://github.com/Leaflet/Leaflet.draw/issues/129). Those comments led us to Leaflet.Editable, which was the easiest and cleanest solution for Sir FOGG.