### PR TITLE
Add azimuth display and enable min/max for inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "react-input-range": "^1.3.0",
         "react-leaflet": "^2.7.0",
         "react-leaflet-draw": "0.19.0",
+        "react-leaflet-semicircle": "^2.0.12",
         "react-modal": "^3.16.1",
         "react-select": "^5.7.7",
         "react-virtualized-auto-sizer": "^1.0.20",
@@ -29646,6 +29647,11 @@
       "resolved": "https://registry.npmjs.org/leaflet-editable/-/leaflet-editable-1.2.0.tgz",
       "integrity": "sha512-wG11JwpL8zqIbypTop6xCRGagMuWw68ihYu4uqrqc5Ep0wnEJeyob7NB2Rt5t74Oih4rwJ3OfwaGbzdowOGfYQ=="
     },
+    "node_modules/leaflet-semicircle": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-semicircle/-/leaflet-semicircle-2.0.4.tgz",
+      "integrity": "sha512-7FV9kGBMSQ1CNZYPxoPCEVpDpiIoh/owZV91BWUKYFik5WuaYij0zGEWOE0elTUlRyTHFJHW4rNfQJ2fqreqnA=="
+    },
     "node_modules/legacy-swc-helpers": {
       "name": "@swc/helpers",
       "version": "0.4.14",
@@ -36656,6 +36662,20 @@
         "leaflet-draw": "^1.0.3",
         "prop-types": "^15.5.2",
         "react": "^16.3.0",
+        "react-leaflet": "^2.0.0"
+      }
+    },
+    "node_modules/react-leaflet-semicircle": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/react-leaflet-semicircle/-/react-leaflet-semicircle-2.0.12.tgz",
+      "integrity": "sha512-zE4thWNJ17CLiNs4wgGkr3nogNo3N6ETHT78O2nIqPrkNd+rT0FrdGrk9PEkT1tfjnmspX4hw0tV6nCot43QZw==",
+      "dependencies": {
+        "leaflet-semicircle": "^2.0.4"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.0.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0",
         "react-leaflet": "^2.0.0"
       }
     },
@@ -66486,6 +66506,11 @@
       "resolved": "https://registry.npmjs.org/leaflet-editable/-/leaflet-editable-1.2.0.tgz",
       "integrity": "sha512-wG11JwpL8zqIbypTop6xCRGagMuWw68ihYu4uqrqc5Ep0wnEJeyob7NB2Rt5t74Oih4rwJ3OfwaGbzdowOGfYQ=="
     },
+    "leaflet-semicircle": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-semicircle/-/leaflet-semicircle-2.0.4.tgz",
+      "integrity": "sha512-7FV9kGBMSQ1CNZYPxoPCEVpDpiIoh/owZV91BWUKYFik5WuaYij0zGEWOE0elTUlRyTHFJHW4rNfQJ2fqreqnA=="
+    },
     "legacy-swc-helpers": {
       "version": "npm:@swc/helpers@0.4.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -71807,6 +71832,14 @@
       "integrity": "sha512-aOB7Nqgl79l62L7vHxhdyKJD6ep+1Q+qTfnrYfmcgF+yK0A1lQA2fUv9N4C0HCbejcyiqx1XYchSCw9Q+Vtc3A==",
       "requires": {
         "lodash-es": "^4.17.10"
+      }
+    },
+    "react-leaflet-semicircle": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/react-leaflet-semicircle/-/react-leaflet-semicircle-2.0.12.tgz",
+      "integrity": "sha512-zE4thWNJ17CLiNs4wgGkr3nogNo3N6ETHT78O2nIqPrkNd+rT0FrdGrk9PEkT1tfjnmspX4hw0tV6nCot43QZw==",
+      "requires": {
+        "leaflet-semicircle": "^2.0.4"
       }
     },
     "react-lifecycles-compat": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-input-range": "^1.3.0",
     "react-leaflet": "^2.7.0",
     "react-leaflet-draw": "0.19.0",
+    "react-leaflet-semicircle": "^2.0.12",
     "react-modal": "^3.16.1",
     "react-select": "^5.7.7",
     "react-virtualized-auto-sizer": "^1.0.20",

--- a/src/components/MapPreview/MapPreview.js
+++ b/src/components/MapPreview/MapPreview.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { Polygon } from 'react-leaflet';
+import { Polygon, Circle, Polyline } from 'react-leaflet';
+import { SemiCircle } from 'react-leaflet-semicircle';
 
 import { useLayers } from '../../hooks';
 import { LayersContext } from '../../context';
@@ -46,6 +47,7 @@ const MapPreview = ({
   onDrawEdited,
   featureRef = useRef(),
   emptyMap = false,
+  azimuthDisplay
 }) => {
   const layers = useLayers(availableLayers, fetchLayerData);
 
@@ -176,6 +178,109 @@ const MapPreview = ({
     }
   }
 
+  let featuresArray = [];
+
+  if (!emptyMap) {
+    featuresArray = features.map((feature) => {
+      const { geometry, properties } = feature;
+
+      const {
+        shapeOptions = {},
+        onClick,
+        onMouseover,
+        onMouseout
+      } = properties;
+
+      const { style = {} } = shapeOptions;
+
+      const featureProps = {
+        ...style,
+        onClick,
+        onMouseover,
+        onMouseout
+      };
+
+      if (geometry.type === 'Point') {
+        const latLngs = latLngFromGeoJson(feature);
+
+        return latLngs.map(({ lat, lng }, index) => {
+          return (
+            <Marker
+              key={`${lat}-${lng}-${index}`}
+              position={[lat, lng]}
+              {...featureProps}
+            />
+          );
+        });
+      }
+
+      if (geometry.type === 'Polygon') {
+        const coordinates = coordinatesFromGeoJson({
+          type: 'FeatureCollection',
+          features: [feature]
+        });
+
+        return coordinates.map((set) => {
+          return set.map((position, index) => {
+            const fixedPosition = position.map((coordinates) => [
+              coordinates[1],
+              coordinates[0]
+            ]);
+            return (
+              <Polygon
+                key={`${coordinates[0]}-${coordinates[1]}-${index}`}
+                color={AVAILABLE_COLORS[index]}
+                positions={fixedPosition}
+                {...featureProps}
+              />
+            );
+          });
+        });
+      }
+
+      return null;
+    });
+  }
+
+  if (azimuthDisplay) {
+    const { center, start, stop } = azimuthDisplay;
+
+    featuresArray.push(
+      <Circle
+        center={center}
+        radius={1500}
+        fill={false}
+      />
+    );
+
+    if (start === stop) {
+      const angleRadians = start * Math.PI / 180;
+      const earthRadius = 6371000; // meters
+      const [centerLat, centerLon] = center;
+
+      const endLat = centerLat + (1500 / earthRadius) * Math.cos(angleRadians) * (180 / Math.PI);
+      const endLon = centerLon + (1500 / earthRadius) * Math.sin(angleRadians) * (180 / Math.PI) / Math.cos(centerLat * Math.PI / 180);
+
+      featuresArray.push(
+        <Polyline
+          positions={[[centerLat, centerLon], [endLat, endLon]]}
+          weight={3}
+        />
+      );
+    } else if (!((start === 0 && stop === 360) || (start === 360 && stop === 0))) {
+      featuresArray.push(
+        <SemiCircle
+          position={center}
+          radius={1500}
+          weight={3}
+          startAngle={start}
+          stopAngle={stop}
+          fillOpacity={0.25}
+        />
+      );
+    }
+  }
+
   return (
     <LayersContext.Provider value={{ ...layers }}>
       <figure className="map-preview">
@@ -189,65 +294,7 @@ const MapPreview = ({
             controlOptions={drawControlOptions}
             shapeOptions={shapeOptions}
           >
-            {!emptyMap && features.map((feature) => {
-              const { geometry, properties } = feature;
-
-              const {
-                shapeOptions = {},
-                onClick,
-                onMouseover,
-                onMouseout
-              } = properties;
-
-              const { style = {} } = shapeOptions;
-
-              const featureProps = {
-                ...style,
-                onClick,
-                onMouseover,
-                onMouseout
-              };
-
-              if (geometry.type === 'Point') {
-                const latLngs = latLngFromGeoJson(feature);
-
-                return latLngs.map(({ lat, lng }, index) => {
-                  return (
-                    <Marker
-                      key={`${lat}-${lng}-${index}`}
-                      position={[lat, lng]}
-                      {...featureProps}
-                    />
-                  );
-                });
-              }
-
-              if (geometry.type === 'Polygon') {
-                const coordinates = coordinatesFromGeoJson({
-                  type: 'FeatureCollection',
-                  features: [feature]
-                });
-
-                return coordinates.map((set) => {
-                  return set.map((position, index) => {
-                    const fixedPosition = position.map((coordinates) => [
-                      coordinates[1],
-                      coordinates[0]
-                    ]);
-                    return (
-                      <Polygon
-                        key={`${coordinates[0]}-${coordinates[1]}-${index}`}
-                        color={AVAILABLE_COLORS[index]}
-                        positions={fixedPosition}
-                        {...featureProps}
-                      />
-                    );
-                  });
-                });
-              }
-
-              return null;
-            })}
+            {featuresArray}
           </MapPreviewDraw>
         </Map>
         <figcaption className="map-preview-header">
@@ -320,7 +367,8 @@ MapPreview.propTypes = {
   onDrawCreated: PropTypes.func,
   onDrawEdited: PropTypes.func,
   featureRef: PropTypes.object,
-  emptyMap: PropTypes.bool
+  emptyMap: PropTypes.bool,
+  azimuthDisplay: PropTypes.object
 };
 
 export default MapPreview;

--- a/src/components/MapPreview/MapPreview.js
+++ b/src/components/MapPreview/MapPreview.js
@@ -258,8 +258,16 @@ const MapPreview = ({
       const earthRadius = 6371000; // meters
       const [centerLat, centerLon] = center;
 
-      const endLat = centerLat + (1500 / earthRadius) * Math.cos(angleRadians) * (180 / Math.PI);
-      const endLon = centerLon + (1500 / earthRadius) * Math.sin(angleRadians) * (180 / Math.PI) / Math.cos(centerLat * Math.PI / 180);
+      const endLat = centerLat
+        + (1500 / earthRadius)
+        * Math.cos(angleRadians)
+        * (180 / Math.PI);
+
+      const endLon = centerLon
+        + (1500 / earthRadius)
+        * Math.sin(angleRadians)
+        * (180 / Math.PI)
+        / Math.cos(centerLat * Math.PI / 180);
 
       featuresArray.push(
         <Polyline

--- a/src/components/MapPreview/MapPreview.js
+++ b/src/components/MapPreview/MapPreview.js
@@ -247,6 +247,7 @@ const MapPreview = ({
 
     featuresArray.push(
       <Circle
+        key={`azimuth-circle-${center[0]}-${center[1]}`}
         center={center}
         radius={1500}
         fill={false}
@@ -271,6 +272,7 @@ const MapPreview = ({
 
       featuresArray.push(
         <Polyline
+          key={`azimuth-polyline-${start}-${stop}`}
           positions={[[centerLat, centerLon], [endLat, endLon]]}
           weight={3}
         />
@@ -278,6 +280,7 @@ const MapPreview = ({
     } else if (!((start === 0 && stop === 360) || (start === 360 && stop === 0))) {
       featuresArray.push(
         <SemiCircle
+          key={`azimuth-semicircle-${start}-${stop}`}
           position={center}
           radius={1500}
           weight={3}

--- a/src/components/MapPreview/MapPreview.test.js
+++ b/src/components/MapPreview/MapPreview.test.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Circle, Polyline } from 'react-leaflet';
+import { SemiCircle } from 'react-leaflet-semicircle';
 import { shallow } from 'enzyme';
 
 import MapPreview from './';
@@ -68,6 +70,112 @@ describe('MapPreview', () => {
       expect(lastCoordinates.text()).toEqual(
         `Lat: ${fcCoordinatesLast[1].toFixed(3)}, Long: ${fcCoordinatesLast[0].toFixed(3)}`
       );
+    });
+  });
+
+  describe('Azimuth Display', () => {
+    const baseAzimuthParams = {
+      center: ALEXANDRIA_COORDINATES
+    };
+
+    it('should render only a circle if start=0 and stop=360', () => {
+      const mapPreview = shallow(
+        <MapPreview
+          geoJson={featureCollection}
+          azimuthDisplay={{
+            ...baseAzimuthParams,
+            start: 0,
+            stop: 360
+          }}
+        />
+      );
+      const mapPreviewCircle = mapPreview.find(Circle);
+      const mapPreviewSemicircle = mapPreview.find(SemiCircle);
+      const mapPreviewPolyline = mapPreview.find(Polyline);
+
+      expect(mapPreviewCircle).toHaveLength(1);
+      expect(mapPreviewSemicircle).toHaveLength(0);
+      expect(mapPreviewPolyline).toHaveLength(0);
+    });
+
+    it('should render only a circle if start=360 and stop=0', () => {
+      const mapPreview = shallow(
+        <MapPreview
+          geoJson={featureCollection}
+          azimuthDisplay={{
+            ...baseAzimuthParams,
+            start: 360,
+            stop: 0
+          }}
+        />
+      );
+      const mapPreviewCircle = mapPreview.find(Circle);
+      const mapPreviewSemicircle = mapPreview.find(SemiCircle);
+      const mapPreviewPolyline = mapPreview.find(Polyline);
+
+      expect(mapPreviewCircle).toHaveLength(1);
+      expect(mapPreviewSemicircle).toHaveLength(0);
+      expect(mapPreviewPolyline).toHaveLength(0);
+    });
+
+    it('should render a circle and polyline if start=stop', () => {
+      const mapPreview = shallow(
+        <MapPreview
+          geoJson={featureCollection}
+          azimuthDisplay={{
+            ...baseAzimuthParams,
+            start: 120,
+            stop: 120
+          }}
+        />
+      );
+      const mapPreviewCircle = mapPreview.find(Circle);
+      const mapPreviewSemicircle = mapPreview.find(SemiCircle);
+      const mapPreviewPolyline = mapPreview.find(Polyline);
+
+      expect(mapPreviewCircle).toHaveLength(1);
+      expect(mapPreviewSemicircle).toHaveLength(0);
+      expect(mapPreviewPolyline).toHaveLength(1);
+    });
+
+    it('should render a circle and semicircle if start > stop', () => {
+      const mapPreview = shallow(
+        <MapPreview
+          geoJson={featureCollection}
+          azimuthDisplay={{
+            ...baseAzimuthParams,
+            start: 80,
+            stop: 120
+          }}
+        />
+      );
+      const mapPreviewCircle = mapPreview.find(Circle);
+      const mapPreviewSemicircle = mapPreview.find(SemiCircle);
+      const mapPreviewPolyline = mapPreview.find(Polyline);
+
+      expect(mapPreviewCircle).toHaveLength(1);
+      expect(mapPreviewSemicircle).toHaveLength(1);
+      expect(mapPreviewPolyline).toHaveLength(0);
+    });
+
+    it('should render a circle and semicircle if start < stop', () => {
+      const mapPreview = shallow(
+        <MapPreview
+          geoJson={featureCollection}
+          azimuthDisplay={{
+            ...baseAzimuthParams,
+            start: 340,
+            stop: 20
+          }}
+        />
+      );
+      const mapPreviewCircle = mapPreview.find(Circle);
+      const mapPreviewSemicircle = mapPreview.find(SemiCircle);
+      const mapPreviewPolyline = mapPreview.find(Polyline);
+
+      expect(mapPreviewCircle).toHaveLength(1);
+      expect(mapPreviewSemicircle).toHaveLength(1);
+      expect(mapPreviewPolyline).toHaveLength(0);
     });
   });
 });

--- a/src/hooks/useInput.js
+++ b/src/hooks/useInput.js
@@ -43,7 +43,9 @@ const INPUT_PROPS_WHITELIST = [
   'isMulti',
   'inputProps',
   'ref',
-  'selectionStart'
+  'selectionStart',
+  'min',
+  'max'
 ];
 
 const INPUT_LIST_TYPES = ['radio', 'checkbox'];


### PR DESCRIPTION
Adds an azimuth display which takes a start and end azimuth angle and displays the result as a semicircle. If it's a 0-360 range nothing will display. If the start and end are the same it will be a line. Also enables passing min/max values to an input.